### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ $ cd rap
 $ mvn clean install -N
 $ mvn clean install -pl bundles/org.eclipse.rap.rwt -am
 $ mvn clean install -pl bundles/org.eclipse.rap.jface -am
+$ mvn clean install -pl bundles/org.eclipse.rap.fileupload -am
 $ mvn clean install -pl bundles/org.eclipse.rap.filedialog -am
 $ mvn clean install -pl tests/org.eclipse.rap.rwt.testfixture -am
 ```


### PR DESCRIPTION
Add fileupload bundle in rap build sequence. filedialog requires fileupload 
Building tested in docker.
```
FROM debian:9

RUN     apt-get update \
        && apt-get install -y openjdk-8-jdk-headless ant maven ivy git \
        && git clone -b webspoon-7.1 https://github.com/HiromuHota/pentaho-commons-xul.git \
        && cd pentaho-commons-xul/pentaho-xul-swt \
        && ant clean-all resolve publish-local \
        && cd ../../ \
        && git clone -b webspoon-3.1-maintenance https://github.com/HiromuHota/rap.git \
        && cd rap \
        && mvn clean install -N \
        && mvn clean install -pl bundles/org.eclipse.rap.rwt -am \
        && mvn clean install -pl bundles/org.eclipse.rap.jface -am \
        && mvn clean install -pl bundles/org.eclipse.rap.fileupload -am \
        && mvn clean install -pl bundles/org.eclipse.rap.filedialog -am \
        && mvn clean install -pl tests/org.eclipse.rap.rwt.testfixture -am \
        && cd ../ \
        && git clone -b webspoon-7.1 https://github.com/HiromuHota/pentaho-kettle.git \
        && cd pentaho-kettle/ui/ \
        && ant clean-all resolve publish-local \
        && cd ../assembly \
        && ant clean-all resolve war
```