### PR TITLE
Adding `save as` behaviour for `FileDialog.open()`

### DIFF
--- a/ui/src/main/java/org/eclipse/swt/widgets/FileDialog.java
+++ b/ui/src/main/java/org/eclipse/swt/widgets/FileDialog.java
@@ -74,6 +74,11 @@ public class FileDialog implements IFileDialog {
 
   public String open() {
     String filePath = null;
+    
+    if ( ( style & SWT.SAVE ) > 0 ) {
+      fileDialogMode = VfsFileChooserDialog.VFS_DIALOG_SAVEAS;
+    }
+    
     FileObject returnFile =
         vfsFileChooserDialog.open( parent, fileName, filterExtensions, filterNames, fileDialogMode );
     File file = null;


### PR DESCRIPTION
added checking of mode open for `FileDialog`, if mode equals `SWT.SAVE` use `save as` behaviour