### PR TITLE
Use internalization key instead of hardcode

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/core/widget/ConditionEditor.java
+++ b/ui/src/main/java/org/pentaho/di/ui/core/widget/ConditionEditor.java
@@ -551,7 +551,7 @@ public class ConditionEditor extends Canvas {
       case AREA_SUBCONDITION:
         mPop = new Menu( widget );
         MenuItem miEdit = new MenuItem( mPop, SWT.PUSH );
-        miEdit.setText( "Edit condition" );
+        miEdit.setText( BaseMessages.getString( PKG, "ConditionEditor.EditCondition.Label" ) );
         miEdit.addSelectionListener( new SelectionAdapter() {
           @Override
           public void widgetSelected( SelectionEvent e ) {


### PR DESCRIPTION
Fix hardcoded `Edit condition` text on existing internalization key `ConditionEditor.EditCondition.Label`