### PR TITLE
Ensure selected step/job entry can be copied/cut (fix #155)

### DIFF
--- a/ui/src/main/java/org/pentaho/di/ui/spoon/job/JobGraph.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/job/JobGraph.java
@@ -516,6 +516,7 @@ public class JobGraph extends AbstractGraph implements XulEventHandler, Redrawab
             case DragAndDropContainer.TYPE_BASE_JOB_ENTRY: // Create a new Job Entry on the canvas
               JobEntryCopy jge = spoon.newJobEntry( jobMeta, entry, false );
               if ( jge != null ) {
+                jobMeta.unselectAll();
                 PropsUI.setLocation( jge, p.x, p.y );
                 jge.setDrawn();
                 redraw();

--- a/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGraph.java
+++ b/ui/src/main/java/org/pentaho/di/ui/spoon/trans/TransGraph.java
@@ -729,7 +729,6 @@ public class TransGraph extends AbstractGraph implements XulEventHandler, Redraw
           }
 
           stepMeta.drawStep();
-          stepMeta.setSelected( true );
           PropsUI.setLocation( stepMeta, p.x, p.y );
 
           if ( newstep ) {


### PR DESCRIPTION
Step/job entry selection upon drag&drop a new one was inconsitent between step and job entry.
By changing how a step/job entry get selected/unselected, this patch ensures selected steps/job entries can be copied/cut.