### PR TITLE
Use //# for sourceURL instead of deprecated //@

### DIFF
--- a/ui/src/main/resources/org/pentaho/di/ui/spoon/canvas.js
+++ b/ui/src/main/resources/org/pentaho/di/ui/spoon/canvas.js
@@ -1,4 +1,4 @@
-//@ sourceURL=canvas.js
+//# sourceURL=canvas.js
 /*! ******************************************************************************
  *
  * Pentaho Data Integration


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma