### PR TITLE
Cherry-pick the fix for [PDI-17948]

### DIFF
--- a/assemblies/static/src/assembly/assembly.xml
+++ b/assemblies/static/src/assembly/assembly.xml
@@ -34,6 +34,14 @@
         <include>docs/**</include>
       </includes>
     </fileSet>
+    <!-- images -->
+    <fileSet>
+      <directory>${project.basedir}/src/main/resources/static</directory>
+      <outputDirectory>content/common-ui/resources/themes</outputDirectory>
+      <includes>
+        <include>**</include>
+      </includes>
+    </fileSet>
 
     <!-- the remaining static resources -->
     <fileSet>


### PR DESCRIPTION
This PR cherry-picks https://github.com/pentaho/pentaho-kettle/pull/6753.
Some css files (globalRuby.css, mantleRuby.css, MantleStyle.css) are still not resolved.
This would fix #142.