### PR TITLE
Merge HiromuHota/webspoon-docker into HiromuHota/pentaho-kettle

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,20 @@ $ unzip ~/Downloads/pdi-ce-$dist.zip
 $ cd $CATALINA_HOME
 $ cp -r ~/data-integration/system ./
 $ cp -r ~/data-integration/plugins ./
-$ wget https://raw.githubusercontent.com/HiromuHota/webspoon-docker/$version/install.sh
+
+# see [1] below
+$ wget https://raw.githubusercontent.com/HiromuHota/pentaho-kettle/$version/docker/install.sh
 $ chmod +x install.sh
 $ ./install.sh
+
+# see [2] below
 $ export CATALINA_OPTS="-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
 $ ./bin/startup.sh
 ```
 
-Instead of exporting `CATALINA_OPTS` like above, `org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true` can be added to `conf/catalina.properties`.
+[1]: 0.9.0.21 and before, use `https://raw.githubusercontent.com/HiromuHota/webspoon-docker/$version/install.sh` instead.
+
+[2]: Instead of exporting `CATALINA_OPTS` like above, `org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true` can be added to `conf/catalina.properties`.
 
 # How to config (optional)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,38 @@
+FROM tomcat:jdk8
+MAINTAINER Hiromu Hota <hiromu.hota@hal.hitachi.com>
+ENV JAVA_OPTS="-Xms1024m -Xmx2048m"
+RUN rm -rf ${CATALINA_HOME}/webapps/* \
+    && mkdir ${CATALINA_HOME}/webapps/ROOT \
+    && echo "<% response.sendRedirect(\"spoon\"); %>" > ${CATALINA_HOME}/webapps/ROOT/index.jsp
+
+ARG base=9.0
+ARG patch=21
+ARG version=0.$base.$patch
+ARG dist=9.0.0.0-423
+
+RUN groupadd -r tomcat \
+    && useradd -r --create-home -g tomcat tomcat \
+    && chown -R tomcat:tomcat ${CATALINA_HOME}
+USER tomcat
+
+RUN wget -q https://sourceforge.net/projects/pentaho/files/Pentaho%20$base/client-tools/pdi-ce-$dist.zip && \
+  unzip -q pdi-ce-$dist.zip && \
+  mv data-integration/system ${CATALINA_HOME}/system && \
+  mv data-integration/plugins ${CATALINA_HOME}/plugins && \
+  mv data-integration/simple-jndi ${CATALINA_HOME}/simple-jndi && \
+  mv data-integration/samples ${CATALINA_HOME}/samples && \
+  mv data-integration/LICENSE.txt ${CATALINA_HOME}/webSpoon-LICENSE.txt && \
+  rm pdi-ce-$dist.zip && \
+  rm -rf data-integration
+
+ARG CACHEBUST=1
+
+RUN echo "org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true" | tee -a conf/catalina.properties
+COPY --chown=tomcat:tomcat install.sh /tmp/install.sh
+RUN sh /tmp/install.sh
+
+ADD --chown=tomcat:tomcat https://github.com/HiromuHota/pentaho-kettle/releases/download/webspoon%2F$version/webspoon-security-$dist-$patch.jar ${CATALINA_HOME}/lib/
+RUN echo "CLASSPATH="$CATALINA_HOME"/lib/webspoon-security-$dist-$patch.jar" | tee ${CATALINA_HOME}/bin/setenv.sh
+COPY --chown=tomcat:tomcat catalina.policy ${CATALINA_HOME}/conf/
+RUN mkdir -p $HOME/.kettle/users && mkdir -p $HOME/.pentaho/users
+RUN mkdir -p $HOME/.kettle/data && cp -r ${CATALINA_HOME}/samples $HOME/.kettle/data/samples

--- a/docker/Dockerrun.aws.json
+++ b/docker/Dockerrun.aws.json
@@ -1,0 +1,23 @@
+{
+  "AWSEBDockerrunVersion": 2,
+  "containerDefinitions": [
+    {
+      "name": "webSpoon",
+      "image": "hiromuhota/webspoon",
+      "essential": true,
+      "memory": 1920,
+      "environment": [
+        {
+          "name": "JAVA_OPTS",
+          "value": "-Xms1024m -Xmx1920m"
+        }
+      ],
+      "portMappings": [
+        {
+          "hostPort": 80,
+          "containerPort": 8080
+        }
+      ]
+    }
+  ]
+}

--- a/docker/Jenkinsfile
+++ b/docker/Jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+  agent any
+  environment {
+    version      = 'nightly'
+  }
+  stages {
+    stage('Build') {
+      steps {
+        sh '''
+          docker build --build-arg version=$version --build-arg CACHEBUST=$BUILD_NUMBER -t hiromuhota/webspoon:$version --pull=true .
+        '''
+      }
+    }
+    stage('Publish') {
+      steps {
+          sh '''
+            docker push hiromuhota/webspoon:$version
+          '''
+      }
+    }
+  }
+}

--- a/docker/Jenkinsfile
+++ b/docker/Jenkinsfile
@@ -6,9 +6,11 @@ pipeline {
   stages {
     stage('Build') {
       steps {
-        sh '''
-          docker build --build-arg version=$version --build-arg CACHEBUST=$BUILD_NUMBER -t hiromuhota/webspoon:$version --pull=true .
-        '''
+        dir("docker") {
+          sh '''
+            docker build --build-arg version=$version --build-arg CACHEBUST=$BUILD_NUMBER -t hiromuhota/webspoon:$version --pull=true .
+          '''
+        }
       }
     }
     stage('Publish') {

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,90 @@
+# How to build an image
+
+```
+$ docker build --no-cache -t hiromuhota/webspoon:latest .
+```
+
+# Tags
+
+| Tag | 0.8.1.ZZ and lower | 0.8.2.ZZ | 0.8.3.ZZ and higher |
+| --- | --- | --- | --- |
+| nightly | Latest commit of webSpoon without plugins | Latest commit of webSpoon with plugins | <-- Ditto |
+| nightly-full | Latest commit of webSpoon with plugins | Identical to nightly, but deprecated | Discontinued |
+| latest | Latest release of webSpoon without plugins | Latest release of webSpoon with plugins | <-- Ditto |
+| latest-full | Latest release of webSpoon with plugins | Identical to latest, but deprecated | Discontinued |
+| 0.X.Y.ZZ | 0.X.Y.ZZ of webSpoon without plugins | 0.X.Y.ZZ of webSpoon with plugins | <-- Ditto |
+| 0.X.Y.ZZ-full | 0.X.Y.ZZ of webSpoon with plugins | Identical to 0.X.Y.ZZ, but deprecated | Discontinued |
+
+# How to use the image
+
+## Basic usage
+
+```
+$ docker run -d -p 8080:8080 hiromuhota/webspoon
+```
+
+Please access `http://ip-address:8080/spoon/spoon`.
+
+## Advanced usage
+
+### Java heap size
+
+The Java heap size is configured as `-Xms1024m -Xmx2048m` by default, but can be overridden as `-Xms1024m -Xmx1920m` for example when a server has only 2GB of memory.
+
+```
+$ docker run -d -p 8080:8080 \
+-e JAVA_OPTS="-Xms1024m -Xmx1920m" \
+hiromuhota/webspoon
+```
+
+### User config and data persistence/share
+
+If the configuration files should be shared among containers, add `-v kettle:/home/tomcat/.kettle -v pentaho:/home/tomcat/.pentaho` as
+
+```
+$ docker run -d -p 8080:8080 \
+-v kettle:/home/tomcat/.kettle -v pentaho:/home/tomcat/.pentaho \
+hiromuhota/webspoon
+```
+
+or execute the following docker-compose command
+
+```
+$ docker-compose up -d
+```
+
+### webSpoon config
+
+From 0.8.0.14, spoon.war is pre-extracted at `$CATALINA_HOME/webapps/spoon` so that configs such as `web.xml` can be configured at run-time using a bind mount.
+If you want to enable user authentication, for example, download [web.xml](https://github.com/HiromuHota/pentaho-kettle/blob/webspoon-8.2/assemblies/static/src/main/resources-filtered/WEB-INF/web.xml) and edit it as described [here](https://github.com/HiromuHota/pentaho-kettle#user-authentication).
+Then add `-v $(pwd)/web.xml:/usr/local/tomcat/webapps/spoon/WEB-INF/web.xml` to the command.
+
+```
+$ docker run -d -p 8080:8080 \
+-v $(pwd)/web.xml:/usr/local/tomcat/webapps/spoon/WEB-INF/web.xml \
+hiromuhota/webspoon
+```
+
+Similarly, `$CATALINA_HOME/webapps/spoon/WEB-INF/spring/security.xml` can be configured at run-time.
+
+### Security manager
+
+To enable the [custom security manager](https://github.com/HiromuHota/pentaho-kettle/wiki/Admin%3A-Security#file-access-control-by-a-custom-security-manager-experimental), enable [user authentication
+](https://github.com/HiromuHota/pentaho-kettle/wiki/Admin%3A-Security#user-authentication) and add `-e CATALINA_OPTS="-Djava.security.manager=org.pentaho.di.security.WebSpoonSecurityManager -Djava.security.policy=/usr/local/tomcat/conf/catalina.policy"` to the run command.
+
+```
+$ docker run -d -p 8080:8080 \
+-e CATALINA_OPTS="-Djava.security.manager=org.pentaho.di.security.WebSpoonSecurityManager -Djava.security.policy=/usr/local/tomcat/conf/catalina.policy" \
+-v $(pwd)/web.xml:/usr/local/tomcat/webapps/spoon/WEB-INF/web.xml \
+-v $(pwd)/catalina.policy:/usr/local/tomcat/conf/catalina.policy \
+hiromuhota/webspoon
+```
+
+## Debug
+
+```
+$ docker run -d -p 8080:8080 -p 8000:8000 \
+-e JPDA_ADDRESS=8000 \
+-e CATALINA_OPTS="-Dorg.eclipse.rap.rwt.developmentMode=true" \
+hiromuhota/webspoon catalina.sh jpda run
+```

--- a/docker/catalina.policy
+++ b/docker/catalina.policy
@@ -1,0 +1,22 @@
+grant
+{
+  permission java.io.FilePermission "${java.io.tmpdir}", "read";
+  permission java.io.FilePermission "${java.io.tmpdir}/-", "read,write,delete";
+  permission java.io.FilePermission "${catalina.home}/webapps/spoon/rwt-resources", "write,delete";
+  permission java.io.FilePermission "${catalina.home}/webapps/spoon/rwt-resources/-", "read,write,delete";
+
+  permission java.io.FilePermission "${java.home}/lib/-", "read";
+  permission java.io.FilePermission "${catalina.home}/webapps/spoon/-", "read";
+  permission java.io.FilePermission "${user.home}/.pentaho", "read";
+  permission java.io.FilePermission "${user.home}/.pentaho/metastore", "read";
+  permission java.io.FilePermission "${catalina.home}/lib/-", "read";
+  permission java.io.FilePermission "${catalina.home}/plugins/-", "read";
+  permission java.io.FilePermission "${catalina.home}/ui/-", "read";
+  permission java.io.FilePermission "${catalina.home}/-", "read";
+  permission java.io.FilePermission "${catalina.home}/.", "read";
+  permission java.io.FilePermission "repositories.xml", "read";
+
+  // For SpoonGit
+  permission java.io.FilePermission "${user.home}/.gitconfig", "read";
+  permission java.io.FilePermission "${user.home}/.gitignore_global", "read";
+};

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  webspoon:
+    image: hiromuhota/webspoon
+    ports:
+      - "8080:8080"
+    volumes:
+      - kettle:/home/tomcat/.kettle
+      - pentaho:/home/tomcat/.pentaho
+    environment:
+      - "JAVA_OPTS=-Xms1024m -Xmx2048m"
+volumes:
+  kettle:
+  pentaho:

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -33,7 +33,7 @@ wget -q https://raw.githubusercontent.com/HiromuHota/pentaho-karaf-assembly/webs
 
 echo 'Configuring Carte'
 mkdir ${CATALINA_HOME}/system/kettle
-wget -q https://raw.githubusercontent.com/HiromuHota/webspoon-docker/$version/slave-server-config.xml -O ${CATALINA_HOME}/system/kettle/slave-server-config.xml || exit $?
+wget -q https://raw.githubusercontent.com/HiromuHota/pentaho-kettle/$version/docker/slave-server-config.xml -O ${CATALINA_HOME}/system/kettle/slave-server-config.xml || exit $?
 
 echo 'Removing Karaf cache'
 rm -rf ${CATALINA_HOME}/system/karaf/caches/webspoonservletcontextlistener || true

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ -z ${version} ]; then echo "version is unset" && exit 1; fi
+if [ -z ${dist} ]; then echo "dist is unset" && exit 1; fi
+if [ -z ${CATALINA_HOME} ]; then echo "CATALINA_HOME is unset" && exit 1; fi
+
+echo 'Downloading and extracting spoon.war'
+wget -q https://github.com/HiromuHota/pentaho-kettle/releases/download/webspoon%2F$version/spoon.war || exit $?
+mkdir ${CATALINA_HOME}/webapps/spoon
+unzip -q spoon.war -d ${CATALINA_HOME}/webapps/spoon
+rm spoon.war
+
+echo 'Downloading and replacing plugins'
+wget -q https://github.com/HiromuHota/pdi-platform-utils-plugin/releases/download/webspoon%2F$version/pdi-platform-utils-plugin-core-$dist.jar -O ${CATALINA_HOME}/plugins/platform-utils-plugin/pdi-platform-utils-plugin-core-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/big-data-plugin/releases/download/webspoon%2F$version/hadoop-cluster-ui-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/pentaho/hadoop-cluster-ui/$dist/hadoop-cluster-ui-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pentaho-kettle/releases/download/webspoon%2F$version/repositories-plugin-core-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/org/pentaho/di/plugins/repositories-plugin-core/$dist/repositories-plugin-core-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pentaho-kettle/releases/download/webspoon%2F$version/pdi-engine-configuration-ui-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/org/pentaho/di/plugins/pdi-engine-configuration-ui/$dist/pdi-engine-configuration-ui-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pentaho-kettle/releases/download/webspoon%2F$version/file-open-save-core-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/org/pentaho/di/plugins/file-open-save-core/$dist/file-open-save-core-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pentaho-kettle/releases/download/webspoon%2F$version/file-open-save-new-core-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/org/pentaho/di/plugins/file-open-save-new-core/$dist/file-open-save-new-core-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pentaho-kettle/releases/download/webspoon%2F$version/get-fields-core-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/org/pentaho/di/plugins/get-fields-core/$dist/get-fields-core-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pentaho-kettle/releases/download/webspoon%2F$version/connections-ui-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/org/pentaho/di/plugins/connections-ui/$dist/connections-ui-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pdi-dataservice-server-plugin/releases/download/webspoon%2F$version/pdi-dataservice-server-plugin-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/pentaho/pdi-dataservice-server-plugin/$dist/pdi-dataservice-server-plugin-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/marketplace/releases/download/webspoon%2F$version/pentaho-marketplace-di-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/org/pentaho/pentaho-marketplace-di/$dist/pentaho-marketplace-di-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pentaho-osgi-bundles/releases/download/webspoon%2F$version/pentaho-i18n-webservice-bundle-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/pentaho/pentaho-i18n-webservice-bundle/$dist/pentaho-i18n-webservice-bundle-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pentaho-osgi-bundles/releases/download/webspoon%2F$version/pentaho-kettle-repository-locator-impl-spoon-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/pentaho/pentaho-kettle-repository-locator-impl-spoon/$dist/pentaho-kettle-repository-locator-impl-spoon-$dist.jar || exit $?
+wget -q https://github.com/HiromuHota/pentaho-osgi-bundles/releases/download/webspoon%2F$version/pentaho-pdi-platform-$dist.jar -O ${CATALINA_HOME}/system/karaf/system/pentaho/pentaho-pdi-platform/$dist/pentaho-pdi-platform-$dist.jar || exit $?
+
+echo 'Configuring org.pentaho.requirejs.cfg'
+echo 'context.root=/spoon/osgi' | tee ${CATALINA_HOME}/system/karaf/etc/org.pentaho.requirejs.cfg
+
+echo 'Configuring custom.properties'
+wget -q https://raw.githubusercontent.com/HiromuHota/pentaho-karaf-assembly/webspoon%2F$version/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties -O ${CATALINA_HOME}/system/karaf/etc/custom.properties || exit $?
+
+echo 'Configuring Carte'
+mkdir ${CATALINA_HOME}/system/kettle
+wget -q https://raw.githubusercontent.com/HiromuHota/webspoon-docker/$version/slave-server-config.xml -O ${CATALINA_HOME}/system/kettle/slave-server-config.xml || exit $?
+
+echo 'Removing Karaf cache'
+rm -rf ${CATALINA_HOME}/system/karaf/caches/webspoonservletcontextlistener || true

--- a/docker/k8s/README.md
+++ b/docker/k8s/README.md
@@ -1,0 +1,82 @@
+# Run webSpoon on Kubernetes
+
+Clone this repository and run this command to create required resources (`Deployment` and `Service`).
+
+```sh
+$ kubectl create -f ./k8s
+deployment.apps/webspoon created
+service/webspoon created
+```
+
+Check that webspoon is running.
+
+```sh
+$ kubectl get pod
+NAME                        READY   STATUS              RESTARTS   AGE
+webspoon-78767c7f57-b9fzd   1/1     Running             0          5m7s
+```
+
+Do port forwarding of `8080` port of the service to local machine.
+
+```sh
+kubectl port-forward service/webspoon 8080:8080 &
+```
+
+While port forwarding, access to the port of local machine.
+
+```
+http://localhost:8080
+```
+
+# Shared `~/.kettle` and `~/.pentaho` directory
+
+Pods share `~/.kettle` and `~/.pentaho` directory as PersistentVolumeClaim (PVC).
+If you want to deploy these PVCs to a Kubernetes cluster which only supports `ReadWriteOnce`, you can configure YAML files.
+
+Edit `kettle-pvc.yaml` and `pentaho-pvc.yaml`.
+
+```yaml
+  # - ReadWriteMany # Comment out
+  - ReadWriteOnce # Uncomment
+```
+
+# Customize
+
+## Add `web.xml` etc.
+
+Create your own `web.xml` file and run this command to make ConfigMap including the `web.xml`.
+
+```sh
+$ kubectl create configmap webspoon-config-cm --from-file web.xml
+```
+
+Then, edit `deployment.yaml` and uncomment this section to mount ConfigMap to containers.
+
+```yaml
+        volumeMounts:
+        ...
+        # - mountPath: /usr/local/tomcat/webapps/spoon/WEB-INF/web.xml
+        #   name: webspoon-config-cm
+        #   subPath: web.xml
+        ...
+      volumes:
+      # - name: webspoon-config-cm
+      #   configMap:
+      #     name: webspoon-config-cm
+```
+
+File locations by default
+
+| File | Mount target in webSpoon pod |
+|-|-|
+| `web.xml` | `/usr/local/tomcat/webapps/spoon/WEB-INF/web.xml` |
+| `catalina.policy` | `/usr/local/tomcat/conf/catalina.policy` |
+| `security.xml` | `/usr/local/tomcat/webapps/spoon/WEB-INF/spring/security.xml`|
+
+# Tear down
+
+```sh
+$ kubectl delete -f ./k8s
+# If you created ConfigMap
+$ kubectl delete configmap webspoon-config-cm
+```

--- a/docker/k8s/deployment.yaml
+++ b/docker/k8s/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    run: webspoon
+  name: webspoon
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: webspoon
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        run: webspoon
+    spec:
+      containers:
+      - env:
+        - name: JAVA_OPTS
+          value: -Xms1024m -Xmx2048m
+        image: hiromuhota/webspoon
+        imagePullPolicy: ""
+        name: webspoon
+        ports:
+        - containerPort: 8080
+        resources: {}
+        volumeMounts:
+        - mountPath: /home/tomcat/.kettle
+          name: kettle-pvc
+        - mountPath: /home/tomcat/.pentaho
+          name: pentaho-pvc
+        # # When you created your own config file, uncomment each section depending on file.
+        # - mountPath: /usr/local/tomcat/webapps/spoon/WEB-INF/web.xml
+        #   name: webspoon-config-cm
+        #   subPath: web.xml
+        # - mountPath: /usr/local/tomcat/conf/catalina.policy
+        #   name: webspoon-config-cm
+        #   subPath: catalina.policy
+        # - mountPath: /usr/local/tomcat/webapps/spoon/WEB-INF/spring/security.xml
+        #   name: webspoon-config-cm
+        #   subPath: security.xml
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes:
+      - name: kettle-pvc
+        persistentVolumeClaim:
+          claimName: kettle-pvc
+      - name: pentaho-pvc
+        persistentVolumeClaim:
+          claimName: pentaho-pvc
+      # # Uncomment to mount ConfigMap if you created ConfigMap
+      # - name: webspoon-config-cm
+      #   configMap:
+      #     name: webspoon-config-cm
+status: {}

--- a/docker/k8s/kettle-pvc.yaml
+++ b/docker/k8s/kettle-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: kettle-pvc
+spec:
+  accessModes:
+  - ReadWriteMany
+  # - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/docker/k8s/pentaho-pvc.yaml
+++ b/docker/k8s/pentaho-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pentaho-pvc
+spec:
+  accessModes:
+  - ReadWriteMany
+  # - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/docker/k8s/service.yaml
+++ b/docker/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    run: webspoon
+  name: webspoon
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    targetPort: 8080
+  selector:
+    run: webspoon
+status:
+  loadBalancer: {}

--- a/docker/slave-server-config.xml
+++ b/docker/slave-server-config.xml
@@ -1,0 +1,5 @@
+<slave_config>
+  <max_log_lines>10000</max_log_lines>
+  <max_log_timeout_minutes>2880</max_log_timeout_minutes>
+  <object_timeout_minutes>240</object_timeout_minutes>
+</slave_config>


### PR DESCRIPTION
I'm merging HiromuHota/webspoon-docker into HiromuHota/pentaho-kettle.
HiromuHota/webspoon-docker was originally experimental, but no any more. It is actually the recommended way of deployment.
Another reason is that contributors might get confused which repository they are supposed to submit an issue to. By merging into a single repository, there will be one single place for issues.

HiromuHota/webspoon-docker will be archived and become read-only, but past issues will remain visible.