### PR TITLE
fixing the path to file slave-server-config.xml in install.sh script

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -33,7 +33,7 @@ wget -q https://raw.githubusercontent.com/HiromuHota/pentaho-karaf-assembly/webs
 
 echo 'Configuring Carte'
 mkdir ${CATALINA_HOME}/system/kettle
-wget -q https://raw.githubusercontent.com/HiromuHota/pentaho-kettle/webspoon%2F$version/docker/slave-server-config.xml -O ${CATALINA_HOME}/system/kettle/slave-server-config.xml || exit $?
+wget -q https://raw.githubusercontent.com/HiromuHota/pentaho-kettle/webspoon-$base/docker/slave-server-config.xml -O ${CATALINA_HOME}/system/kettle/slave-server-config.xml || exit $?
 
 echo 'Removing Karaf cache'
 rm -rf ${CATALINA_HOME}/system/karaf/caches/webspoonservletcontextlistener || true

--- a/openshift/Dockerfile
+++ b/openshift/Dockerfile
@@ -1,0 +1,59 @@
+FROM tomcat:jdk8
+
+ENV JAVA_OPTS="-Xms1024m -Xmx2048m"
+RUN rm -rf ${CATALINA_HOME}/webapps/* \
+    && mkdir ${CATALINA_HOME}/webapps/ROOT \
+    && echo "<% response.sendRedirect(\"spoon\"); %>" > ${CATALINA_HOME}/webapps/ROOT/index.jsp
+
+ARG base=9.0
+ARG patch=21
+ARG version=0.$base.$patch
+ARG dist=9.0.0.0-423
+
+RUN groupadd -r tomcat \
+    && useradd -r --create-home -g tomcat tomcat \
+    && chown -R tomcat:0 ${CATALINA_HOME} \
+    && chmod -R g=u  ${CATALINA_HOME}
+
+USER tomcat
+
+RUN wget -q https://sourceforge.net/projects/pentaho/files/Pentaho%20$base/client-tools/pdi-ce-$dist.zip && \
+  unzip -q pdi-ce-$dist.zip && \
+  mv data-integration/system ${CATALINA_HOME}/system && \
+  mv data-integration/plugins ${CATALINA_HOME}/plugins && \
+  mv data-integration/simple-jndi ${CATALINA_HOME}/simple-jndi && \
+  mv data-integration/samples ${CATALINA_HOME}/samples && \
+  mv data-integration/LICENSE.txt ${CATALINA_HOME}/webSpoon-LICENSE.txt && \
+  rm pdi-ce-$dist.zip && \
+  rm -rf data-integration
+
+ARG CACHEBUST=1
+
+RUN echo "org.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true" | tee -a conf/catalina.properties
+COPY docker/install.sh /tmp/install.sh
+RUN sh /tmp/install.sh
+
+ADD  https://github.com/HiromuHota/pentaho-kettle/releases/download/webspoon%2F$version/webspoon-security-$dist-$patch.jar ${CATALINA_HOME}/lib/
+RUN echo "CLASSPATH="$CATALINA_HOME"/lib/webspoon-security-$dist-$patch.jar" | tee ${CATALINA_HOME}/bin/setenv.sh
+COPY docker/catalina.policy ${CATALINA_HOME}/conf/
+RUN mkdir -p $HOME/.kettle/users && mkdir -p $HOME/.pentaho/users
+RUN mkdir -p $HOME/.kettle/data && cp -r ${CATALINA_HOME}/samples $HOME/.kettle/data/samples
+
+USER root
+
+RUN chown -R tomcat:0 /usr/local/tomcat \
+    && chmod -R g=u  ${CATALINA_HOME} \
+    && chown -R tomcat:0 ${CATALINA_HOME} \
+    && chmod -R g=u ${CATALINA_HOME} \
+    && chmod g=u /etc/passwd
+
+COPY openshift/uid_entrypoint /
+
+RUN chown -R tomcat:0 /home/tomcat \
+    && chmod -R g=u /home/tomcat
+
+USER tomcat
+
+ENTRYPOINT ["/uid_entrypoint"]
+CMD ["catalina.sh","run"]
+

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,0 +1,21 @@
+# brief introduction
+
+I make available a Webspoon template focused on a development or test environment for the community. We start from an ephemeral configuration that can scale as much as they want since this service is statelessI make available a Webspoon template focused on a development or test environment for the community. We start from an ephemeral configuration that can scale as much as they want since this service is stateless.
+
+## Basic usage
+
+```
+$ oc create -f webspoon-template.yaml
+```
+
+The previous step loads the template and its artefacts to the current namespace or project. T
+
+```
+$ oc process webspoon-template -p NAME=webspoon | oc create -f -
+```
+
+Finally we process the template and initialize the parameter, created each of the artifacts.
+
+- - -
+
+> I hope you find it useful.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -1,6 +1,6 @@
 # brief introduction
 
-I make available a Webspoon template focused on a development or test environment for the community. We start from an ephemeral configuration that can scale as much as they want since this service is statelessI make available a Webspoon template focused on a development or test environment for the community. We start from an ephemeral configuration that can scale as much as they want since this service is stateless.
+I make available a Webspoon template focused on a development or test environment for the community. We start from an ephemeral configuration that can scale as much as they want since this service is stateless
 
 ## Basic usage
 
@@ -8,8 +8,7 @@ I make available a Webspoon template focused on a development or test environmen
 $ oc create -f webspoon-template.yaml
 ```
 
-The previous step loads the template and its artefacts to the current namespace or project. T
-
+The previous step loads the template and its artefacts to the current namespace or project.
 ```
 $ oc process webspoon-template -p NAME=webspoon | oc create -f -
 ```

--- a/openshift/uid_entrypoint
+++ b/openshift/uid_entrypoint
@@ -1,0 +1,7 @@
+#!/bin/sh
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "webspoon-default:x:$(id -u):0:webspoon user,,,:/home/tomcat:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+exec "$@"

--- a/openshift/webspoon-template.yaml
+++ b/openshift/webspoon-template.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: webspoon-template
+  author: "Franklin Gómez Otero"
+  annotations:
+    openshift.io/display-name: "Webspoon Pentaho Data Integration (Ephemeral)"
+    openshift.io/documentation-url: "https://github.com/HiromuHota/pentaho-kettle/wiki"
+    openshift.io/provider-display-name: "Franklin Gómez Otero"
+    description: >-
+      Spoon tool web version for ETL execution similar to the tool
+      desktop Spoon. Preloaded with a series of plugins and example of transformations (kettle files).
+      The purpose of this template is exploratory and therefore ephemeral.
+labels:
+  app: "webspoon"
+
+message: "Enjoy the tool ... Wait a few minutes for it to be ready !!!"
+
+# PARAMETERS
+parameters:
+  - name: NAME
+    description: "App name"
+    value: webspoon
+    required: true
+
+objects:
+
+# IMAGESTREAMS
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: ${NAME}
+  spec:
+    dockerImageRepository:
+
+# BUILDCONFIGS
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: ${NAME}
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: webspoon:9.0
+    source:
+      git:
+        ref: openshift
+        uri: https://github.com/fgomezotero/pentaho-kettle.git
+      type: Git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: openshift/Dockerfile
+      type: Docker
+    triggers:
+      - type: "ConfigChange" 
+
+# DEPLOYMENTCONFIGS
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    name: ${NAME}
+  spec:
+    replicas: 1
+    selector:
+      app: ${NAME}
+      deploymentconfig: ${NAME}
+    template:
+      metadata:
+        labels:
+          app: ${NAME}
+          deploymentconfig: ${NAME}
+      spec:
+        containers:
+        - image: webspoon:9.0
+          imagePullPolicy: IfNotPresent
+          name: ${NAME}
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${NAME}
+        from:
+          kind: ImageStreamTag
+          name: webspoon:9.0
+      type: ImageChange
+
+# SERVICES
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ${NAME}
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: ${NAME}
+      deploymentconfig: ${NAME}
+    sessionAffinity: None
+    type: ClusterIP
+
+# ROUTE    
+- apiVersion: v1
+  kind: Route
+  metadata:
+    annotations:
+      openshift.io/host.generated: "true"
+    name: ${NAME}
+  spec:
+    port:
+      targetPort: 8080-tcp
+    to:
+      kind: Service
+      name: ${NAME}
+      weight: 100
+    wildcardPolicy: None


### PR DESCRIPTION
The next call
wget -q https://raw.githubusercontent.com/HiromuHota/pentaho-kettle/webspoon%2F$version/docker/slave-server-config.xml -O ${CATALINA_HOME}/system/kettle/slave-server-config.xml || exit $?
return 404 not found file. I changed that call to reference $base variable and it works.

Regards.